### PR TITLE
Book model and firebase service code refactored

### DIFF
--- a/lib/apis/firebase/book.dart
+++ b/lib/apis/firebase/book.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:conveneapp/features/book/model/book_model.dart';
 import 'package:conveneapp/features/search/model/search_book_model.dart';
@@ -6,33 +8,15 @@ final CollectionReference users = FirebaseFirestore.instance.collection('users')
 
 class BookApi {
   Future<List<BookModel>> getCurrentBooks({required String uid}) async {
-    final List<BookModel> _books = [];
-    final books = await users.doc(uid).collection("currentBooks").orderBy("title").get();
-
-    for (final book in books.docs) {
-      _books.add(
-        BookModel(
-          id: book.id,
-          authors: List<String>.from(book["authors"]),
-          coverImage: book["coverImage"],
-          currentPage: book.data()['currentPage'] ?? 0,
-          pageCount: book["pageCount"],
-          title: book["title"],
-        ),
-      );
+    //TODO: Handle the error where method is called
+    try {
+      final bookMap = await users.doc(uid).collection("currentBooks").orderBy("title").get();
+      List<BookModel> books = bookMap.docs.map((b) => BookModel.fromMap(b.data()).copyWith(id: b.id)).toList();
+      return books;
+    } catch (e) {
+      log(e.toString());
+      throw (e);
     }
-
-    // TODO: why does this not work?
-    // try {
-    //   books.docs.map((e) {
-    //     _books.add(BookModel.fromMap(e.data()));
-    //   });
-    // } catch (e) {
-    //   print(e);
-    // }
-    // print(_books);
-
-    return _books;
   }
 
   Future<void> finishBook({required BookModel book, required String uid}) async {

--- a/lib/apis/firebase/book.dart
+++ b/lib/apis/firebase/book.dart
@@ -8,15 +8,10 @@ final CollectionReference users = FirebaseFirestore.instance.collection('users')
 
 class BookApi {
   Future<List<BookModel>> getCurrentBooks({required String uid}) async {
-    //TODO: Handle the error where method is called
-    try {
-      final bookMap = await users.doc(uid).collection("currentBooks").orderBy("title").get();
-      List<BookModel> books = bookMap.docs.map((b) => BookModel.fromMap(b.data()).copyWith(id: b.id)).toList();
-      return books;
-    } catch (e) {
-      log(e.toString());
-      throw (e);
-    }
+    //TODO: #37 Handle the error where method is called.
+    final bookMap = await users.doc(uid).collection("currentBooks").orderBy("title").get();
+    List<BookModel> books = bookMap.docs.map((b) => BookModel.fromMap(b.data()).copyWith(id: b.id)).toList();
+    return books;
   }
 
   Future<void> finishBook({required BookModel book, required String uid}) async {

--- a/lib/apis/firebase/book.dart
+++ b/lib/apis/firebase/book.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:conveneapp/features/book/model/book_model.dart';
 import 'package:conveneapp/features/search/model/search_book_model.dart';

--- a/lib/features/book/model/book_model.dart
+++ b/lib/features/book/model/book_model.dart
@@ -9,6 +9,14 @@ class BookModel {
   final int currentPage;
   final DateTime? dateCompleted;
 
+  static const idKey = 'id';
+  static const titleKey = 'title';
+  static const authorsKey = 'authors';
+  static const pageCountKey = 'pageCount';
+  static const coverImageKey = 'coverImage';
+  static const currentPageKey = 'currentPage';
+  static const dateCompletedKey = 'dateCompleted';
+
   BookModel({
     required this.id,
     required this.title,
@@ -41,25 +49,25 @@ class BookModel {
 
   Map<String, dynamic> toMap() {
     return {
-      'id': id,
-      'title': title,
-      'authors': authors,
-      'pageCount': pageCount,
-      'coverImage': coverImage,
-      'currentPage': currentPage,
-      'dateCompleted': dateCompleted,
+      idKey: id,
+      titleKey: title,
+      authorsKey: authors,
+      pageCountKey: pageCount,
+      coverImageKey: coverImage,
+      currentPageKey: currentPage,
+      dateCompletedKey: dateCompleted,
     };
   }
 
   factory BookModel.fromMap(Map<String, dynamic> map) {
     return BookModel(
-      id: map['id'],
-      title: map['title'],
-      authors: List<String>.from(map['authors']),
-      pageCount: map['pageCount'] ?? 0,
-      coverImage: map['coverImage'],
-      currentPage: map['currentPage'],
-      dateCompleted: DateTime.fromMillisecondsSinceEpoch(map['dateCompleted']),
+      id: map[idKey] ?? "",
+      title: map[titleKey],
+      authors: List<String>.from(map[authorsKey]),
+      pageCount: map[pageCountKey] ?? 0,
+      coverImage: map[coverImageKey],
+      currentPage: map[currentPageKey] ?? 0,
+      dateCompleted: map[dateCompletedKey] != null ? DateTime.fromMillisecondsSinceEpoch(map[dateCompletedKey]) : null,
     );
   }
 


### PR DESCRIPTION
> Release Version:

## Release Notes

Hey, I was taking a look at the code, and I found this.

In `book.dart` there is this block of code that was not executing
```
    // TODO: why does this not work?
    try {
      books.docs.map((e) {
        _books.add(BookModel.fromMap(e.data()));
      });
    } catch (e) {
      print(e);
    }
    print(_books);
```

The reason for this bug was the following:
1. The `dateCompleted` is `null` and even though the field is nullable its being passed through this `DateTime.fromMillisecondsSinceEpoch(map['dateCompleted'])` which caused the error.
2. Also needed to add the `toList()` after the `map` block ended.

In order to handle errors a new issue is created at #37 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [ ] The QA checklist below has been completed

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Currently using the `fromMap` was not working for the book model because the id is actually not stored in the Firestore document.

## What is the new behavior?

- Now the `fromMap` works because if the id is `null` an empty string acts as the default.
- The firebase get statement is now in the `try` block which helps to catch the errors.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
