### PR TITLE
bug: reactive image size doesn't overflow on bigger displays

### DIFF
--- a/lib/features/authentication/view/auth_page.dart
+++ b/lib/features/authentication/view/auth_page.dart
@@ -23,10 +23,11 @@ class AuthPage extends ConsumerWidget {
               height: 50,
             ),
             const Spacer(),
-            const Padding(
-              padding: EdgeInsets.all(30.0),
+            Padding(
+              padding: const EdgeInsets.all(30.0),
               child: Image(
-                image: AssetImage("assets/reading.png"),
+                image: const AssetImage("assets/reading.png"),
+                height: (MediaQuery.of(context).size.height * 0.3),
               ),
             ),
             const Spacer(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
 dev_dependencies:
   mocktail_image_network: ^0.2.0
-  mocktail: ^0.2.0 
+  mocktail: ^0.2.0
   flutter_launcher_icons: ^0.9.2
   flutter_lints: ^1.0.4
   flutter_test:


### PR DESCRIPTION
# Description

The image was overflowing on the sign in page, which caused it to not get accepted on iOS

Fixes #18
